### PR TITLE
Use PlugIn Name as default File Prefix

### DIFF
--- a/app/source/controller.cpp
+++ b/app/source/controller.cpp
@@ -837,6 +837,11 @@ void Controller::createProject ()
 		pluginClassNameStr = pluginNameStr;
 		makeValidCppName (pluginClassNameStr);
 	}
+
+	if (filenamePrefixStr.empty()) {
+		filenamePrefixStr = pluginNameStr;
+	}
+
 	auto cmakeProjectName = pluginNameStr;
 	makeValidCppName (cmakeProjectName);
 


### PR DESCRIPTION
If the user leave the Field "Filename Prefix" empty we should use the PlugIn Name as File Prefix instead of use the "myPlugin" Prefix from the CMake Creation File